### PR TITLE
Add mountpoint detection support. Fix #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Mac OS X:
 		device: '/dev/disk0',
 		description: 'GUID_partition_scheme',
 		size: '*750.2 GB'
+		mountpoint: '/'
 	},
 	{
 		device: '/dev/disk1',
@@ -57,6 +58,7 @@ GNU/Linux
 		device: '/dev/sda',
 		description: 'WDC WD10JPVX-75J',
 		size: '931.5G',
+		mountpoint: '/'
 	},
 	{
 		device: '/dev/sr0',
@@ -76,11 +78,13 @@ Windows
 		device: '\\\\.\\PHYSICALDRIVE0',
 		description: 'WDC WD10JPVX-75JC3T0',
 		size: '1000 GB'
+		mountpoint: 'C:'
 	},
 	{
 		device: '\\\\.\\PHYSICALDRIVE1',
 		description: 'Generic STORAGE DEVICE USB Device',
 		size: '15 GB'
+		mountpoint: 'D:'
 	}
 ]
 ```

--- a/build/linux.js
+++ b/build/linux.js
@@ -1,10 +1,24 @@
-var childProcess, tableParser, _;
+var async, childProcess, getMountPoint, tableParser, _;
 
 childProcess = require('child_process');
+
+async = require('async');
 
 _ = require('lodash');
 
 tableParser = require('table-parser');
+
+getMountPoint = function(device, callback) {
+  return childProcess.exec("grep \"^" + device + "\" /proc/mounts | cut -d ' ' -f 2", {}, function(error, stdout, stderr) {
+    if (error != null) {
+      return callback(error);
+    }
+    if (!_.isEmpty(stderr)) {
+      return callback(new Error(stderr));
+    }
+    return callback(null, stdout);
+  });
+};
 
 exports.list = function(callback) {
   return childProcess.exec('lsblk -d --output NAME,MODEL,SIZE', {}, function(error, stdout, stderr) {
@@ -16,15 +30,22 @@ exports.list = function(callback) {
       return callback(new Error(stderr));
     }
     result = tableParser.parse(stdout);
-    result = _.map(result, function(row) {
-      var _ref;
-      return {
-        device: "/dev/" + (_.first(row.NAME)),
-        description: (_ref = row.MODEL) != null ? _ref.join(' ') : void 0,
-        size: _.first(row.SIZE).replace(/,/g, '.')
-      };
-    });
-    return callback(null, result);
+    return async.map(result, function(row, callback) {
+      var device;
+      device = "/dev/" + (_.first(row.NAME));
+      return getMountPoint(device, function(error, mountPoint) {
+        var _ref;
+        if (error != null) {
+          return callback(error);
+        }
+        return callback(null, {
+          device: device,
+          description: (_ref = row.MODEL) != null ? _ref.join(' ') : void 0,
+          size: _.first(row.SIZE).replace(/,/g, '.'),
+          mountpoint: mountPoint || void 0
+        });
+      });
+    }, callback);
   });
 };
 

--- a/build/win32.js
+++ b/build/win32.js
@@ -24,11 +24,12 @@ exports.list = function(callback) {
       driveInfo = _.map(driveInfo, function(element) {
         return element.trim();
       });
-      size = _.parseInt(driveInfo[2]) / 1e+9 || void 0;
+      size = _.parseInt(driveInfo[3]) / 1e+9 || void 0;
       return {
         device: driveInfo[1],
         description: driveInfo[0],
-        size: size != null ? "" + (Math.floor(size)) + " GB" : void 0
+        size: size != null ? "" + (Math.floor(size)) + " GB" : void 0,
+        mountpoint: driveInfo[2]
       };
     });
     return callback(null, result);

--- a/lib/osx.coffee
+++ b/lib/osx.coffee
@@ -1,6 +1,20 @@
 childProcess = require('child_process')
+path = require('path')
+async = require('async')
 _ = require('lodash')
 tableParser = require('table-parser')
+
+getMountPoint = (device, callback) ->
+	childProcess.exec "diskutil info #{device}", {}, (error, stdout, stderr) ->
+		return callback(error) if error?
+
+		if not _.isEmpty(stderr)
+			return callback(new Error(stderr))
+
+		result = tableParser.parse(stdout)
+		mount = _.findWhere(result, Device: [ 'Mount' ])
+		mountPoint = mount?['Identifier:'][1] or mount?[path.basename(device)][0]
+		return callback(null, mountPoint)
 
 exports.list = (callback) ->
 	childProcess.exec 'diskutil list', {}, (error, stdout, stderr) ->
@@ -20,31 +34,26 @@ exports.list = (callback) ->
 		result = _.map result, (row) ->
 			return _.rest(row)
 
-		result = _.map result, (row) ->
-
-			device = row.pop()
+		async.map result, (row, callback) ->
+			device = "/dev/#{row.pop()}"
 			sizeMeasure = row.pop()
 			size = row.pop()
 
-			return {
-				device: "/dev/#{device}"
-				size: "#{size} #{sizeMeasure}"
-				description: row.join(' ')
-			}
-
-		return callback(null, result)
+			getMountPoint device, (error, mountPoint) ->
+				return callback(error) if error?
+				return callback null,
+					device: device
+					size: "#{size} #{sizeMeasure}"
+					description: row.join(' ')
+					mountpoint: mountPoint
+		, callback
 
 exports.isSystem = (drive, callback) ->
 
-	childProcess.exec "diskutil info #{drive.device}", {}, (error, stdout, stderr) ->
+	getMountPoint drive.device, (error, mountPoint) ->
 		return callback(false) if error?
-
-		if not _.isEmpty(stderr)
-			return callback(false)
 
 		# Assume true for /dev/disk0
 		return callback(true) if drive.device is '/dev/disk0'
 
-		result = tableParser.parse(stdout)
-		mountPoint = _.findWhere(result, Device: [ 'Mount' ])?['Identifier:'][1]
 		return callback(mountPoint is '/')

--- a/lib/win32.coffee
+++ b/lib/win32.coffee
@@ -18,12 +18,13 @@ exports.list = (callback) ->
 			driveInfo = _.map driveInfo, (element) ->
 				return element.trim()
 
-			size = _.parseInt(driveInfo[2]) / 1e+9 or undefined
+			size = _.parseInt(driveInfo[3]) / 1e+9 or undefined
 
 			return {
 				device: driveInfo[1],
 				description: driveInfo[0],
 				size: "#{Math.floor(size)} GB" if size?
+				mountpoint: driveInfo[2]
 			}
 
 		return callback(null, result)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "sinon-chai": "~2.6.0"
   },
   "dependencies": {
+    "async": "^1.4.0",
     "lodash": "^3.0.1",
     "table-parser": "0.0.3"
   }

--- a/scripts/win_drives.vbs
+++ b/scripts/win_drives.vbs
@@ -16,7 +16,7 @@ For Each objDrive In colDiskDrives
                 objPartition.DeviceID & """} WHERE AssocClass = " & _
                     "Win32_LogicalDiskToPartition")
         For Each objLogicalDisk In colLogicalDisks
-            Wscript.Echo objDrive.Caption & vbTab & objDrive.DeviceID & vbTab & objDrive.Size
+            Wscript.Echo objDrive.Caption & vbTab & objDrive.DeviceID & vbTab & objLogicalDisk.DeviceID & vbTab & objDrive.Size
         Next
     Next
 Next

--- a/tests/linux.spec.coffee
+++ b/tests/linux.spec.coffee
@@ -13,12 +13,22 @@ describe 'Drivelist LINUX:', ->
 
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
-				@childProcessStub.yields null, '''
+				@childProcessStub.withArgs('lsblk -d --output NAME,MODEL,SIZE').yields null, '''
 					NAME MODEL              SIZE
 					sda  WDC WD10JPVX-75J 931,5G
 					sdb  STORAGE DEVICE    14,7G
 					sr0  DVD+-RW GU90N     1024M
 				''', undefined
+
+				@childProcessStub.withArgs('grep "^/dev/sda" /proc/mounts | cut -d \' \' -f 2').yields null, '''
+					/boot/efi
+				''', undefined
+
+				@childProcessStub.withArgs('grep "^/dev/sdb" /proc/mounts | cut -d \' \' -f 2').yields null, '''
+					/media/johndoe/UNTITLED
+				''', undefined
+
+				@childProcessStub.withArgs('grep "^/dev/sr0" /proc/mounts | cut -d \' \' -f 2').yields null, '', undefined
 
 			afterEach ->
 				@childProcessStub.restore()
@@ -32,16 +42,19 @@ describe 'Drivelist LINUX:', ->
 							device: '/dev/sda'
 							description: 'WDC WD10JPVX-75J'
 							size: '931.5G'
+							mountpoint: '/boot/efi'
 						}
 						{
 							device: '/dev/sdb'
 							description: 'STORAGE DEVICE'
 							size: '14.7G'
+							mountpoint: '/media/johndoe/UNTITLED'
 						}
 						{
 							device: '/dev/sr0'
 							description: 'DVD+-RW GU90N'
 							size: '1024M'
+							mountpoint: undefined
 						}
 					]
 
@@ -51,10 +64,18 @@ describe 'Drivelist LINUX:', ->
 
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
-				@childProcessStub.yields null, '''
+				@childProcessStub.withArgs('lsblk -d --output NAME,MODEL,SIZE').yields null, '''
 					NAME    MODEL           SIZE
 					sda     SD Plus         3.8G
 					mmcblk0                14.4G
+				''', undefined
+
+				@childProcessStub.withArgs('grep "^/dev/sda" /proc/mounts | cut -d \' \' -f 2').yields null, '''
+					/boot/efi
+				''', undefined
+
+				@childProcessStub.withArgs('grep "^/dev/mmcblk0" /proc/mounts | cut -d \' \' -f 2').yields null, '''
+					/media/johndoe/UNTITLED
 				''', undefined
 
 			afterEach ->
@@ -69,11 +90,13 @@ describe 'Drivelist LINUX:', ->
 							device: '/dev/sda'
 							description: 'SD Plus'
 							size: '3.8G'
+							mountpoint: '/boot/efi'
 						}
 						{
 							device: '/dev/mmcblk0'
 							description: undefined
 							size: '14.4G'
+							mountpoint: '/media/johndoe/UNTITLED'
 						}
 					]
 

--- a/tests/osx.spec.coffee
+++ b/tests/osx.spec.coffee
@@ -13,7 +13,8 @@ describe 'Drivelist OSX:', ->
 
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
-				@childProcessStub.yields null, '''
+
+				@childProcessStub.withArgs('diskutil list').yields null, '''
 					/dev/disk0
 						 #:                       TYPE NAME                    SIZE       IDENTIFIER
 						 0:      GUID_partition_scheme                        *750.2 GB   disk0
@@ -31,6 +32,121 @@ describe 'Drivelist OSX:', ->
 						 0:                            elementary OS          *15.7 GB    disk2
 				''', undefined
 
+				@childProcessStub.withArgs('diskutil info /dev/disk0').yields null, '''
+					Device Identifier:        disk0
+					Device Node:              /dev/disk0
+					Part of Whole:            disk0
+					Device / Media Name:      APPLE SSD SM0256G Media
+
+					Volume Name:              Not applicable (no file system)
+
+					Mounted:                  Not applicable (no file system)
+
+					File System:              None
+
+					Content (IOContent):      GUID_partition_scheme
+					OS Can Be Installed:      No
+					Media Type:               Generic
+					Protocol:                 PCI
+					SMART Status:             Verified
+
+					Total Size:               251.0 GB (251000193024 Bytes) (exactly 490234752 512-Byte-Units)
+					Volume Free Space:        Not applicable (no file system)
+					Device Block Size:        512 Bytes
+
+					Read-Only Media:          No
+					Read-Only Volume:         Not applicable (no file system)
+					Ejectable:                No
+
+					Whole:                    Yes
+					Internal:                 Yes
+					Solid State:              Yes
+					OS 9 Drivers:             No
+					Low Level Format:         Not supported
+				''', undefined
+
+				@childProcessStub.withArgs('diskutil info /dev/disk1').yields null, '''
+					Device Identifier:        disk1
+					Device Node:              /dev/disk1
+					Part of Whole:            disk1
+					Device / Media Name:      Macintosh HD
+
+					Volume Name:              Macintosh HD
+
+					Mounted:                  Yes
+					Mount Point:              /
+
+					File System Personality:  Journaled HFS+
+					Type (Bundle):            hfs
+					Name (User Visible):      Mac OS Extended (Journaled)
+					Journal:                  Journal size 24576 KB at offset 0x19502000
+					Owners:                   Enabled
+
+					Content (IOContent):      Apple_HFS
+					OS Can Be Installed:      Yes
+					Recovery Disk:            disk0s3
+					Media Type:               Generic
+					Protocol:                 PCI
+					SMART Status:             Not Supported
+					Volume UUID:              02768F72-AD55-36DD-8EE1-0ADB0590BE56
+					Disk / Partition UUID:    DCD23031-6322-4269-A142-CD36C8FD95D7
+
+					Total Size:               249.8 GB (249779191808 Bytes) (exactly 487849984 512-Byte-Units)
+					Volume Free Space:        201.8 GB (201823002624 Bytes) (exactly 394185552 512-Byte-Units)
+					Device Block Size:        512 Bytes
+					Allocation Block Size:    4096 Bytes
+
+					Read-Only Media:          No
+					Read-Only Volume:         No
+					Ejectable:                No
+
+					Whole:                    Yes
+					Internal:                 Yes
+					Solid State:              Yes
+					OS 9 Drivers:             No
+					Low Level Format:         Not supported
+
+					This disk is a Core Storage Logical Volume (LV).  Core Storage Information:
+					LV UUID:                  DCD23031-6322-4269-A142-CD36C8FD95D7
+					LVF UUID:                 C3BB8BBF-B377-416F-AF8F-07BE6E36B90C
+					LVG UUID:                 BEBAA479-1F77-4691-9911-10A5580850DF
+					Fusion Drive:             No
+					Encrypted:                Yes
+				''', undefined
+
+				@childProcessStub.withArgs('diskutil info /dev/disk2').yields null, '''
+					Device Identifier:        disk2
+					Device Node:              /dev/disk2
+					Part of Whole:            disk2
+					Device / Media Name:      Sony Storage Media Media
+
+					Volume Name:              Not applicable (no file system)
+
+					Mounted:                  Yes
+					Mount Point:              /Volumes/Elementary
+
+					File System:              None
+
+					Content (IOContent):      FDisk_partition_scheme
+					OS Can Be Installed:      No
+					Media Type:               Generic
+					Protocol:                 USB
+					SMART Status:             Not Supported
+
+					Total Size:               7.8 GB (7801405440 Bytes) (exactly 15237120 512-Byte-Units)
+					Volume Free Space:        Not applicable (no file system)
+					Device Block Size:        512 Bytes
+
+					Read-Only Media:          No
+					Read-Only Volume:         Not applicable (no file system)
+					Ejectable:                Yes
+
+					Whole:                    Yes
+					Internal:                 No
+					OS 9 Drivers:             No
+					Low Level Format:         Not supported
+				''', undefined
+
 			afterEach ->
 				@childProcessStub.restore()
 
@@ -43,16 +159,19 @@ describe 'Drivelist OSX:', ->
 							device: '/dev/disk0'
 							description: 'GUID_partition_scheme'
 							size: '*750.2 GB'
+							mountpoint: undefined
 						}
 						{
 							device: '/dev/disk1'
 							description: 'Apple_HFS Macintosh HD'
 							size: '*748.9 GB'
+							mountpoint: '/'
 						}
 						{
 							device: '/dev/disk2'
 							description: 'elementary OS'
 							size: '*15.7 GB'
+							mountpoint: '/Volumes/Elementary'
 						}
 					]
 

--- a/tests/win32.spec.coffee
+++ b/tests/win32.spec.coffee
@@ -14,8 +14,7 @@ describe 'Drivelist WIN32:', ->
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
 				@childProcessStub.yields null, '''
-					WDC WD10JPVX-75JC3T0             	\\\\.\\PHYSICALDRIVE0	1000202273280
-					Generic STORAGE DEVICE USB Device	\\\\.\\PHYSICALDRIVE1	15718510080
+					WDC WD10JPVX-75JC3T0             	\\\\.\\PHYSICALDRIVE0	C:	1000202273280
 				''', undefined
 
 			afterEach ->
@@ -26,16 +25,10 @@ describe 'Drivelist WIN32:', ->
 					expect(error).to.not.exist
 
 					expect(drives).to.deep.equal [
-						{
-							device: '\\\\.\\PHYSICALDRIVE0'
-							description: 'WDC WD10JPVX-75JC3T0'
-							size: '1000 GB'
-						}
-						{
-							device: '\\\\.\\PHYSICALDRIVE1'
-							description: 'Generic STORAGE DEVICE USB Device'
-							size: '15 GB'
-						}
+						device: '\\\\.\\PHYSICALDRIVE0'
+						description: 'WDC WD10JPVX-75JC3T0'
+						size: '1000 GB'
+						mountpoint: 'C:'
 					]
 
 					return done()
@@ -45,8 +38,8 @@ describe 'Drivelist WIN32:', ->
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
 				@childProcessStub.yields null, '''
-					WDC WD10JPVX-75JC3T0         	\\\\.\\PHYSICALDRIVE0	1000202273280
-					Sony Storage Media USB Device	\\\\.\\PHYSICALDRIVE1	7797565440
+					WDC WD10JPVX-75JC3T0         	\\\\.\\PHYSICALDRIVE0	C:	1000202273280
+					Sony Storage Media USB Device	\\\\.\\PHYSICALDRIVE1	D:	7797565440
 				''', undefined
 
 			afterEach ->
@@ -61,11 +54,13 @@ describe 'Drivelist WIN32:', ->
 							device: '\\\\.\\PHYSICALDRIVE0'
 							description: 'WDC WD10JPVX-75JC3T0'
 							size: '1000 GB'
+							mountpoint: 'C:'
 						}
 						{
 							device: '\\\\.\\PHYSICALDRIVE1'
 							description: 'Sony Storage Media USB Device'
 							size: '7 GB'
+							mountpoint: 'D:'
 						}
 					]
 
@@ -76,8 +71,8 @@ describe 'Drivelist WIN32:', ->
 			beforeEach ->
 				@childProcessStub = sinon.stub(childProcess, 'exec')
 				@childProcessStub.yields null, '''
-					WDC WD10JPVX-75JC3T0             	\\\\.\\PHYSICALDRIVE0	1000202273280
-					Generic STORAGE DEVICE USB Device	\\\\.\\PHYSICALDRIVE1
+					WDC WD10JPVX-75JC3T0             	\\\\.\\PHYSICALDRIVE0	C:	1000202273280
+					Generic STORAGE DEVICE USB Device	\\\\.\\PHYSICALDRIVE1	D:
 				''', undefined
 
 			afterEach ->
@@ -92,11 +87,13 @@ describe 'Drivelist WIN32:', ->
 							device: '\\\\.\\PHYSICALDRIVE0'
 							description: 'WDC WD10JPVX-75JC3T0'
 							size: '1000 GB'
+							mountpoint: 'C:'
 						}
 						{
 							device: '\\\\.\\PHYSICALDRIVE1'
 							description: 'Generic STORAGE DEVICE USB Device'
 							size: undefined
+							mountpoint: 'D:'
 						}
 					]
 


### PR DESCRIPTION
Add a `mountpoint` property to the returned drives. If a mount point is not detected, `mountpoint` is `undefined`.

Uses the following approach to detect mount points:

- Linux: Reads `/proc/mounts`.
- Mac OS X: Parses `diskutil info`.
- Windows: Use a custom Visual Basic script.