### PR TITLE
Surround Windows script path in double quotes

### DIFF
--- a/build/win32.js
+++ b/build/win32.js
@@ -9,7 +9,7 @@ path = require('path');
 exports.list = function(callback) {
   var script;
   script = path.join(__dirname, '..', 'scripts', 'win_drives.vbs');
-  return childProcess.exec("cscript " + script + " //Nologo", {}, function(error, stdout, stderr) {
+  return childProcess.exec("cscript \"" + script + "\" //Nologo", {}, function(error, stdout, stderr) {
     var output, result;
     if (error != null) {
       return callback(error);

--- a/lib/win32.coffee
+++ b/lib/win32.coffee
@@ -5,7 +5,7 @@ path = require('path')
 exports.list = (callback) ->
 	script = path.join(__dirname, '..', 'scripts', 'win_drives.vbs')
 
-	childProcess.exec "cscript #{script} //Nologo", {}, (error, stdout, stderr) ->
+	childProcess.exec "cscript \"#{script}\" //Nologo", {}, (error, stdout, stderr) ->
 		return callback(error) if error?
 
 		if not _.isEmpty(stderr)


### PR DESCRIPTION
Windows complains if the path contains spaces otherwise.