### PR TITLE
Get drives until parenthesis in OS X

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -8,7 +8,7 @@ function get_until_paren {
   awk 'match($0, "\\("){ print substr($0, 0, RSTART - 1) }'
 }
 
-DISKS="`diskutil list | grep '^\/'`"
+DISKS="`diskutil list | grep '^\/' | get_until_paren`"
 
 for disk in $DISKS; do
   diskinfo="`diskutil info $disk`"


### PR DESCRIPTION
Take this example:

	/dev/disk0 (internal, physical):
		#:                       TYPE NAME                    SIZE      IDENTIFIER
		0:      GUID_partition_scheme                        *500.1 GB  disk0
		1:                        EFI EFI                     209.7 MB  disk0s1
		2:                  Apple_HFS Untitled                499.2 GB  disk0s2
		3:                 Apple_Boot Recovery HD             650.0 MB  disk0s3

We use `grep '^\/'` to get the drives, which given the input above will
return:

	/dev/disk0 (internal, physical):

We then iterate trough every word assuming it is a drive, therefore we
erroneously thinkg `(internal` and `physical):` are disk names.

This is fixed by using our `get_until_paren` helper to make sure we
ignore the parenthesis after the disk.