### PR TITLE
Escape backslashes in Windows script

### DIFF
--- a/scripts/win32.vbs
+++ b/scripts/win32.vbs
@@ -16,7 +16,7 @@ For Each objDrive In colDiskDrives
                 objPartition.DeviceID & """} WHERE AssocClass = " & _
                     "Win32_LogicalDiskToPartition")
         For Each objLogicalDisk In colLogicalDisks
-            Wscript.Echo "device: """ & objDrive.DeviceID & """"
+            Wscript.Echo "device: """ & Replace(objDrive.DeviceID, "\", "\\") & """"
             Wscript.Echo "description: """ & objDrive.Caption & """"
             Wscript.Echo "size: """ & Int(objDrive.Size / 1e+9) & " GB"""
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"


### PR DESCRIPTION
Backslashes don't need to be escaped in VBScript, but they do need to be
escaped in NodeJS.