### PR TITLE
Surround script paths with double quotes

### DIFF
--- a/build/scripts.js
+++ b/build/scripts.js
@@ -12,8 +12,8 @@ scriptsPath = path.join(__dirname, '..', 'scripts');
 
 exports.paths = {
   win32: "cscript \"" + (path.join(scriptsPath, 'win32.vbs')) + "\" //Nologo",
-  darwin: path.join(scriptsPath, 'darwin.sh'),
-  linux: path.join(scriptsPath, 'linux.sh')
+  darwin: path.join("\"" + scriptsPath + "\"", 'darwin.sh'),
+  linux: path.join("\"" + scriptsPath + "\"", 'linux.sh')
 };
 
 exports.run = function(script, callback) {

--- a/lib/scripts.coffee
+++ b/lib/scripts.coffee
@@ -7,8 +7,8 @@ scriptsPath = path.join(__dirname, '..', 'scripts')
 
 exports.paths =
 	win32: "cscript \"#{path.join(scriptsPath, 'win32.vbs')}\" //Nologo"
-	darwin: path.join(scriptsPath, 'darwin.sh')
-	linux: path.join(scriptsPath, 'linux.sh')
+	darwin: path.join("\"#{scriptsPath}\"", 'darwin.sh')
+	linux: path.join("\"#{scriptsPath}\"", 'linux.sh')
 
 exports.run = (script, callback) ->
 	child_process.exec script, (error, stdout, stderr) ->


### PR DESCRIPTION
This prevents paths containing space to fail on UNIX based operating
systems.

Fixes: https://github.com/resin-io/drivelist/issues/39