### PR TITLE
Linux: Separate multiple mountpoints with a comma

### DIFF
--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -14,7 +14,7 @@ for disk in $DISKS; do
   device="/dev/$disk"
   description=`lsblk -d $device --output MODEL | ignore_first_line`
   size=`lsblk -d $device --output SIZE | ignore_first_line | trim`
-  mountpoint=`grep "^$device" /proc/mounts | cut -d ' ' -f 2`
+  mountpoint=`grep "^$device" /proc/mounts | cut -d ' ' -f 2 | tr '\n' ','`
 
   echo "device: $device"
   echo "description: $description"


### PR DESCRIPTION
In GNU/Linux, if a drive has multiple mountpoints, the `mountpoint`
value contains line endings, resulting in output like this which
confuses drivelist parser:

    device: /dev/sda
    description: STORAGE DEVICE
    size: 7,5G
    mountpoint: /media/jviotti/resin-boot
    /media/jviotti/resin-conf
    /media/jviotti/resin-root
    system: False

A good enough solution is to replace new lines with commas, so the
`mountpoint` contains a comma separated list of paths.