### PR TITLE
Execute scripts with execFile

### DIFF
--- a/build/scripts.js
+++ b/build/scripts.js
@@ -11,13 +11,15 @@ path = require('path');
 scriptsPath = path.join(__dirname, '..', 'scripts');
 
 exports.paths = {
-  win32: "cscript \"" + (path.join(scriptsPath, 'win32.vbs')) + "\" //Nologo",
-  darwin: path.join("\"" + scriptsPath + "\"", 'darwin.sh'),
-  linux: path.join("\"" + scriptsPath + "\"", 'linux.sh')
+  win32: 'win32.bat',
+  darwin: path.join(scriptsPath, 'darwin.sh'),
+  linux: path.join(scriptsPath, 'linux.sh')
 };
 
 exports.run = function(script, callback) {
-  return child_process.exec(script, function(error, stdout, stderr) {
+  return child_process.execFile(script, {
+    cwd: scriptsPath
+  }, function(error, stdout, stderr) {
     if (error != null) {
       return callback(error);
     }

--- a/lib/scripts.coffee
+++ b/lib/scripts.coffee
@@ -6,12 +6,23 @@ path = require('path')
 scriptsPath = path.join(__dirname, '..', 'scripts')
 
 exports.paths =
-	win32: "cscript \"#{path.join(scriptsPath, 'win32.vbs')}\" //Nologo"
-	darwin: path.join("\"#{scriptsPath}\"", 'darwin.sh')
-	linux: path.join("\"#{scriptsPath}\"", 'linux.sh')
+
+	# Passing the full patch to the .bat file to
+	# execFile doesn't seem to work.
+	# Passing just the file name with the correct `cwd`
+	# do work for some reason.
+	win32: 'win32.bat',
+
+	darwin: path.join(scriptsPath, 'darwin.sh')
+	linux: path.join(scriptsPath, 'linux.sh')
 
 exports.run = (script, callback) ->
-	child_process.exec script, (error, stdout, stderr) ->
+	child_process.execFile script,
+
+		# Needed for execFile to run .bat files
+		cwd: scriptsPath
+
+	, (error, stdout, stderr) ->
 		return callback(error) if error?
 
 		if not _.str.isBlank(stderr)

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -1,0 +1,2 @@
+@echo off
+cscript "%CD%\win32.vbs" //NoLogo

--- a/tests/scripts.spec.coffee
+++ b/tests/scripts.spec.coffee
@@ -27,11 +27,11 @@ describe 'Scripts:', ->
 		describe 'given an error when running the script', ->
 
 			beforeEach ->
-				@childProcessExecStub = sinon.stub(child_process, 'exec')
-				@childProcessExecStub.yields(new Error('script error'))
+				@childProcessExecFileStub = sinon.stub(child_process, 'execFile')
+				@childProcessExecFileStub.yields(new Error('script error'))
 
 			afterEach ->
-				@childProcessExecStub.restore()
+				@childProcessExecFileStub.restore()
 
 			it 'should yield the error', (done) ->
 				scripts.run 'foo', (error, output) ->
@@ -43,11 +43,11 @@ describe 'Scripts:', ->
 		describe 'given the script outputs to stderr', ->
 
 			beforeEach ->
-				@childProcessExecStub = sinon.stub(child_process, 'exec')
-				@childProcessExecStub.yields(null, '', 'script error')
+				@childProcessExecFileStub = sinon.stub(child_process, 'execFile')
+				@childProcessExecFileStub.yields(null, '', 'script error')
 
 			afterEach ->
-				@childProcessExecStub.restore()
+				@childProcessExecFileStub.restore()
 
 			it 'should yield an error', (done) ->
 				scripts.run 'foo', (error, output) ->
@@ -59,11 +59,11 @@ describe 'Scripts:', ->
 		describe 'given the script outputs to stdout and a blank string to stderr', ->
 
 			beforeEach ->
-				@childProcessExecStub = sinon.stub(child_process, 'exec')
-				@childProcessExecStub.yields(null, 'foo bar', '   ')
+				@childProcessExecFileStub = sinon.stub(child_process, 'execFile')
+				@childProcessExecFileStub.yields(null, 'foo bar', '   ')
 
 			afterEach ->
-				@childProcessExecStub.restore()
+				@childProcessExecFileStub.restore()
 
 			it 'should yield the result', (done) ->
 				scripts.run 'foo', (error, output) ->
@@ -74,11 +74,11 @@ describe 'Scripts:', ->
 		describe 'given the script outputs to stdout', ->
 
 			beforeEach ->
-				@childProcessExecStub = sinon.stub(child_process, 'exec')
-				@childProcessExecStub.yields(null, 'foo bar', '')
+				@childProcessExecFileStub = sinon.stub(child_process, 'execFile')
+				@childProcessExecFileStub.yields(null, 'foo bar', '')
 
 			afterEach ->
-				@childProcessExecStub.restore()
+				@childProcessExecFileStub.restore()
 
 			it 'should yield the result', (done) ->
 				scripts.run 'foo', (error, output) ->


### PR DESCRIPTION
`execFile` is patched by Electron to be able to execute scripts inside
`asar` packages (see https://github.com/atom/electron/issues/3512).

Using `exec`, as we have been doing until now, causes `drivelist` to
throw `ENOENT` on the scripts.

Collateral changes:

- We removed the double quotes between darwin and linux paths to
workaround errors when paths contain spaces.

(see https://github.com/resin-io/drivelist/issues/39).

This is no longer needed when using `execFile` (in fact, this function
throws an error when quoting the path). This was tested manually to
prevent a regression.

- We create an intermediary `win32.bat` script that calls
`win32.vbs` since `execFile` knows how to call this type of file
automatically.