### PR TITLE
Pass full path to *.bat script to execFile

### DIFF
--- a/build/scripts.js
+++ b/build/scripts.js
@@ -13,15 +13,13 @@ os = require('os');
 scriptsPath = path.join(__dirname, '..', 'scripts');
 
 exports.paths = {
-  win32: 'win32.bat',
+  win32: path.join(scriptsPath, 'win32.bat'),
   darwin: path.join(scriptsPath, 'darwin.sh'),
   linux: path.join(scriptsPath, 'linux.sh')
 };
 
 exports.run = function(script, callback) {
-  return child_process.execFile(script, os.platform() === 'win32' ? {
-    cwd: scriptsPath
-  } : void 0, function(error, stdout, stderr) {
+  return child_process.execFile(script, function(error, stdout, stderr) {
     if (error != null) {
       return callback(error);
     }

--- a/lib/scripts.coffee
+++ b/lib/scripts.coffee
@@ -7,23 +7,12 @@ os = require('os')
 scriptsPath = path.join(__dirname, '..', 'scripts')
 
 exports.paths =
-
-	# Passing the full patch to the .bat file to
-	# execFile doesn't seem to work.
-	# Passing just the file name with the correct `cwd`
-	# do work for some reason.
-	win32: 'win32.bat',
-
+	win32: path.join(scriptsPath, 'win32.bat')
 	darwin: path.join(scriptsPath, 'darwin.sh')
 	linux: path.join(scriptsPath, 'linux.sh')
 
 exports.run = (script, callback) ->
-	child_process.execFile script,
-
-		# Needed for execFile to run .bat files
-		cwd: scriptsPath if os.platform() is 'win32'
-
-	, (error, stdout, stderr) ->
+	child_process.execFile script, (error, stdout, stderr) ->
 		return callback(error) if error?
 
 		if not _.str.isBlank(stderr)


### PR DESCRIPTION
I left a comment before about this not working correctly, and explaining
the need of passing the `cwd` option, however it seems that this is now
working fine after the hybrid bat/vbs pull request.