### PR TITLE
Trim trailing commas in parser

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -51,6 +51,11 @@ module.exports = function(input) {
     if (_.isString(result)) {
       return _.object([result], [null]);
     }
-    return result;
+    if (result == null) {
+      return;
+    }
+    return _.mapValues(result, function(value, key) {
+      return _.str.rtrim(value, ',') || null;
+    });
   }));
 };

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -41,4 +41,7 @@ module.exports = (input) ->
 		result = yaml.safeLoad(device)
 		if _.isString(result)
 			return _.object([ result ], [ null ])
-		return result
+		return if not result?
+
+		return _.mapValues result, (value, key) ->
+			return _.str.rtrim(value, ',') or null

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -77,6 +77,14 @@ describe 'Parse:', ->
 			mountpoint: '/Volumes/Elementary'
 		]
 
+	it 'should discard trailing commas', ->
+		m.chai.expect parse '''
+			hello: foo,bar,baz,
+		'''
+		.to.deep.equal [
+			hello: 'foo,bar,baz'
+		]
+
 	it 'should parse multiple devices that are heterogeneous', ->
 		m.chai.expect parse '''
 			hello: world


### PR DESCRIPTION
On GNU/Linux, we emit a comma-separated string of the different
mountpoints of a certain drive, for example `/mnt,/tmp/mnt,`.

For simplicity, the `linux.sh` script replaces all `\n` with a comma,
causing all mountpoints to have a trailing comma, independently of
having a single mountpoint or many.

Fixes: https://github.com/resin-io/drivelist/issues/46