### PR TITLE
Fix boolean values being surrounded by quotes

### DIFF
--- a/build/parse.js
+++ b/build/parse.js
@@ -55,6 +55,9 @@ module.exports = function(input) {
       return;
     }
     return _.mapValues(result, function(value, key) {
+      if (!_.isString(value)) {
+        return value;
+      }
       return _.str.rtrim(value, ',') || null;
     });
   }));

--- a/lib/parse.coffee
+++ b/lib/parse.coffee
@@ -44,4 +44,5 @@ module.exports = (input) ->
 		return if not result?
 
 		return _.mapValues result, (value, key) ->
+			return value if not _.isString(value)
 			return _.str.rtrim(value, ',') or null

--- a/tests/parse.spec.coffee
+++ b/tests/parse.spec.coffee
@@ -85,6 +85,22 @@ describe 'Parse:', ->
 			hello: 'foo,bar,baz'
 		]
 
+	it 'should parse a truthy boolean', ->
+		m.chai.expect parse '''
+			hello: True
+		'''
+		.to.deep.equal [
+			hello: true
+		]
+
+	it 'should parse a falsy boolean', ->
+		m.chai.expect parse '''
+			hello: False
+		'''
+		.to.deep.equal [
+			hello: false
+		]
+
 	it 'should parse multiple devices that are heterogeneous', ->
 		m.chai.expect parse '''
 			hello: world


### PR DESCRIPTION
Instead of `false` or `true` we get `'false'` and `'true'` respectively.