### PR TITLE
Implement name property

### DIFF
--- a/scripts/darwin.sh
+++ b/scripts/darwin.sh
@@ -22,6 +22,7 @@ for disk in $DISKS; do
   echo "description: $description"
   echo "size: $size"
   echo "mountpoint: $mountpoint"
+  echo "name: $device"
 
   if [[ "$device" == "/dev/disk0" ]] || [[ "$mountpoint" == "/" ]]; then
     echo "system: True"

--- a/scripts/linux.sh
+++ b/scripts/linux.sh
@@ -20,6 +20,7 @@ for disk in $DISKS; do
   echo "description: $description"
   echo "size: $size"
   echo "mountpoint: $mountpoint"
+  echo "name: $device"
 
   # We determine if a drive is a system drive
   # by checking the removeable flag.

--- a/scripts/win32.bat
+++ b/scripts/win32.bat
@@ -27,6 +27,7 @@ For Each objDrive In colDiskDrives
             Wscript.Echo "description: """ & objDrive.Caption & """"
             Wscript.Echo "size: """ & Int(objDrive.Size / 1e+9) & " GB"""
             Wscript.Echo "mountpoint: """ & objLogicalDisk.DeviceID & """"
+            Wscript.Echo "name: """ & objLogicalDisk.DeviceID & """"
 
             If objDrive.DeviceID = "\\.\PHYSICALDRIVE0" Then
               Wscript.Echo "system: True"


### PR DESCRIPTION
This property represents the "display name" of a drive. In the case of
OS X and GNU/Linux, this is simply the device name (e.g: `/dev/disk2`)
while on Windows it represents the drive letter (e.g: `C:`).

The purpose of this distinction is to abstract the way end users
identify drives, since something like `\\.\PhysicalDriveN` makes no
sense for a Windows user.